### PR TITLE
Add IPASIS to IP addresses section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [Awseye](https://awseye.com/) - Open-source intelligence (OSINT) and reconnaissance service tracking publicly accessible AWS data
 - [S4E](https://app.s4e.io/) - Continuous Threat Exposure Management platform that offers a web-based cybersecurity solution for comprehensive scanning and vulnerability detection of digital assets like domains, subdomains, IP addresses, and web apps
 - [ipquery.io](https://ipquery.io/) - The IP Address API for Developers
+- [IPASIS](https://ipasis.com/scan) - Real-time IP reputation and email risk scanner with bot detection, VPN/proxy/Tor identification, and trust scoring
 - [domaincodex.com](https://www.domaincodex.com/) - Research 500m+ root domain information and all associated data, including records, IP address, page metadata and much more
 - [APIfreaks.com](https://apifreaks.com/) - Unified API hub providing DNS, WHOIS, IP geolocation, screenshots and commodity data APIs for developers and security teams
 - [HackMyIP](https://hackmyip.com/) - Free privacy and security toolkit with 19+ tools including IP lookup, DNS lookup, DNS leaks test and many others


### PR DESCRIPTION
Added [IPASIS](https://ipasis.com/scan) to the IP addresses section.

IPASIS provides a free online scanner for IP reputation and email risk analysis — checks for VPN/proxy/Tor usage, bot indicators, and returns a trust score. Useful for quick lookups during OSINT investigations.

- **URL:** https://ipasis.com/scan
- **Free to use:** Yes (no signup required for the web scanner)