### PR TITLE
Add CVE PoC Search to the exploits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [Hacking the Cloud](https://hackingthe.cloud/) - Encyclopedia of the attacks/tactics/techniques that offensive security professionals can use on their next cloud exploitation adventure
 - [Living Off The Land Drivers](https://www.loldrivers.io/) - Open-source project that brings together vulnerable, malicious, and known malicious Windows drivers
 - [PwnWiki](http://pwnwiki.io/) - Collection of TTPs (tools, tactics, and procedures) for what to do after access has been gained
+- [CVE PoC Search](https://labs.jamessawyer.co.uk/cves/) - Search public GitHub proof-of-concept repositories by CVE identifier
 - [CVExploits Search](https://cvexploits.io/) - Your comprehensive database for CVE exploits from across the internet
 - [VARIoT](https://www.variotdbs.pl/exploits/) - VARIoT IoT exploits database
 - [Living Off the Orchard: macOS Binaries](https://www.loobins.io/) - Detailed information on various built-in macOS binaries and how they can be used by threat actors for malicious purposes


### PR DESCRIPTION
Adds CVE PoC Search to the Exploits section as a searchable public index of GitHub proof-of-concept repositories by CVE identifier.

Link: https://labs.jamessawyer.co.uk/cves/