### PR TITLE
Add Xquik to social network search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ These can be useful for osint and social engineering.
 - [Instagram](https://www.instagram.com/)
 - [YouTube](https://www.youtube.com/)
 - [Twitter/X](https://twitter.com/)
+- [Xquik](https://xquik.com/) - Search public X posts, inspect public profiles, monitor keywords, and use REST or MCP workflows for X data.
 - [LinkedIn](https://www.linkedin.com/)
 - [Reddit](https://new.reddit.com/)
 - [Pinterest](https://www.pinterest.com/)

--- a/README.md
+++ b/README.md
@@ -422,7 +422,6 @@ These can be useful for osint and social engineering.
 - [Instagram](https://www.instagram.com/)
 - [YouTube](https://www.youtube.com/)
 - [Twitter/X](https://twitter.com/)
-- [Xquik](https://xquik.com/) - Search public X posts, inspect public profiles, monitor keywords, and use REST or MCP workflows for X data.
 - [LinkedIn](https://www.linkedin.com/)
 - [Reddit](https://new.reddit.com/)
 - [Pinterest](https://www.pinterest.com/)
@@ -660,6 +659,7 @@ These can be useful for osint and social engineering.
 - [Whatsmyname](https://whatsmyname.app/) - OSINT tool designed for enumerating usernames across a wide array of websites
 - [Namecheckr](https://www.namecheckr.com/) - Social and Domain Name Availability Search For Brand Professionals
 - [Username Search](https://www.user-searcher.com/) - Free online tool to conduct reverse username search across various social media platforms, online dating sites, forums, and communities simply by providing a username
+- [Xquik](https://xquik.com/) - Search public X posts, inspect public profiles, monitor keywords, and use REST or MCP workflows for X data
 - [TheOrg](https://theorg.com/) - World's biggest network of public org charts
 
 ### Vehicle


### PR DESCRIPTION
## Summary
- Add Xquik to the Social Networks section as an X search and monitoring resource.
- Keep the entry focused on public X post search, public profile inspection, keyword monitoring, REST, and MCP workflows.

## Validation
- git diff --check
- bash scripts/check-dups.sh
- Custom Social Networks duplicate-link check
- Xquik source, docs, API root, MCP overview, and agent skill index links return 200
