### PR TITLE
Add CheckLeaked to Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [ScatteredSecrets](https://scatteredsecrets.com/) - Search data breaches to see if your password has been compromised
 - [InfoStealers.info](https://infostealers.info/) - OSINT made simple. Instant insights from Infostealer data
 - [NiamonX PwnedLookup](https://niamonx.io/) - AI-powered platform for credential leak monitoring, infostealer intelligence and breach investigations
+- [CheckLeaked](https://checkleaked.cc/) - Check if an email, username or phone appears in a data breach, with sources; free searches, developer API and chat bots
 
 ### Leaks
 


### PR DESCRIPTION
Adds **CheckLeaked** ([checkleaked.cc](https://checkleaked.cc/)) to the **Credentials** section.

It's a data-breach search engine: look up an email, username or phone and see whether/where it appears in leaks, with a free tier, a developer API and Telegram/Discord bots. It sits naturally alongside the existing Have I Been Pwned, Dehashed and LeakCheck.io entries.

Entry follows the existing list format:
`- [CheckLeaked](https://checkleaked.cc/) - Check if an email, username or phone appears in a data breach, with sources; free searches, developer API and chat bots`

Disclosure: I'm affiliated with CheckLeaked.