### PR TITLE
Add Argos OSINT to Domains section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [NetCraft SearchDNS](https://searchdns.netcraft.com/) - Search Web by Domain
 - [SpoofChecker](https://spoofchecker.com/) - Spoof Checker detects typosquats and spoofed domains to protect your brand from phishing, fraud, and BEC scams
 - [Cerast Intelligence](https://search.cerast-intelligence.com/) - Search a domain for exposed paths and misconfigurations found by continuous internet-wide scanning
+- [Argos OSINT](https://argos-osint.com/dominio/) - Free unified domain intel dashboard combining WHOIS/RDAP, DoH DNS resolution and subdomain enumeration via crt.sh in a single client-side panel. Spanish-first.
 
 ### URLs
 


### PR DESCRIPTION
Adding [Argos OSINT (/dominio)](https://argos-osint.com/dominio/) to the **Domains** section.

Argos `/dominio` is a free client-side unified domain intelligence dashboard that combines in a single panel:

- WHOIS/RDAP lookup
- DoH DNS resolution (A/AAAA/MX/TXT/NS)
- Subdomain enumeration via crt.sh (Certificate Transparency)

Runs entirely in the browser, no signup, no ads. Spanish-first (underrepresented language in OSINT tooling). Part of a wider suite at argos-osint.com (31 tools + guides + LLM prompts) but only the domain aggregator is being submitted here since it fits the category best.

Appended at the end of Domains as the section is not alphabetically sorted. Happy to move or reformat if you prefer.

Thanks for maintaining this list!