### PR TITLE
Add DomScan to Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [NetCraft SearchDNS](https://searchdns.netcraft.com/) - Search Web by Domain
 - [SpoofChecker](https://spoofchecker.com/) - Spoof Checker detects typosquats and spoofed domains to protect your brand from phishing, fraud, and BEC scams
 - [Cerast Intelligence](https://search.cerast-intelligence.com/) - Search a domain for exposed paths and misconfigurations found by continuous internet-wide scanning
+- [DomScan](https://domscan.net/tools/security) - Domain intelligence and attack-surface checks across DNS, WHOIS/RDAP, TLS, subdomains, reputation, and typosquatting
 
 ### URLs
 


### PR DESCRIPTION
Adds DomScan to the Domains section.

DomScan provides browser-based domain and attack-surface checks for DNS, WHOIS/RDAP, TLS, public subdomains, reputation, and typosquatting. The linked tool page is publicly accessible and the addition follows the existing one-line format.

Validation: `git diff --check`; destination returned HTTP 200.