### PR TITLE
Add osint-recon

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [APIfreaks.com](https://apifreaks.com/) - Unified API hub providing DNS, WHOIS, IP geolocation, screenshots and commodity data APIs for developers and security teams
 - [HackMyIP](https://hackmyip.com/) - Free privacy and security toolkit with 19+ tools including IP lookup, DNS lookup, DNS leaks test and many others
 - [lookup.disclose.io](https://lookup.disclose.io/) - Find who owns any internet asset and the right security & disclosure contact
+- [osint-recon](https://github.com/JMarchiori13/osint-recon) - Passive OSINT reconnaissance framework in Rust: subdomains, DNS, ASN, CT history, GitHub dorking, tech fingerprinting, emails, document metadata and Brazilian context (CNPJ/CEP)
 
 ### Code
 


### PR DESCRIPTION
Adds [osint-recon](https://github.com/JMarchiori13/osint-recon) to the **Attack Surface** section (one line, matching the list's format).

A passive OSINT reconnaissance framework written in Rust for authorized red team engagements: subdomains (crt.sh), DNS-over-HTTPS, ASN/netblocks, certificate transparency history, GitHub dorking, tech fingerprinting, email harvesting, PDF metadata, and a Brazilian context module (CNPJ/CEP). Keyless public sources, JSON/CSV/JSONL export, prebuilt binaries, MIT licensed, CI-tested.

Thanks for maintaining this list!