### PR TITLE
Add SearchWebCode to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [publicwww.com](https://publicwww.com/) - Find any alphanumeric snippet, signature or keyword in the web pages HTML, JS and CSS code
 - [SearchCode](https://searchcode.com/) - Search 75 billion lines of code from 40 million projects
 - [NerdyData](https://www.nerdydata.com/) - Find companies based on their website's tech stack or code
+- [SearchWebCode](https://www.searchwebcode.com/) - Exact-string and regex search over the HTML, JS and CSS of 127 million website homepages
 - [RepoSearch](http://codefinder.org/) - Source code search engine that helps you find implementation details, example usages or just analyze code
 - [SourceGraph](https://about.sourcegraph.com/) - Understand and search across your entire codebase
 - [HotExamples](https://hotexamples.com/) - Search code examples from over 1 million projects


### PR DESCRIPTION
Adds [SearchWebCode](https://www.searchwebcode.com/) to the Code section, next to the other website source-code search engines (publicwww.com, NerdyData).

SearchWebCode indexes the HTML/JS/CSS of ~127M website homepages and supports exact-string and full regular expression queries, with complete matched page source in results and CSV export. Same use cases as PublicWWW/NerdyData: find every site running a given snippet, signature, tracking ID, or framework.

**Disclosure:** this submission is from the team behind SearchWebCode.