### PR TITLE
Add StackScan to Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [Cerast Intelligence](https://search.cerast-intelligence.com/) - Search a domain for exposed paths and misconfigurations found by continuous internet-wide scanning
 - [DomScan](https://domscan.net/tools/security) - Domain intelligence and attack-surface checks across DNS, WHOIS/RDAP, TLS, subdomains, reputation, and typosquatting
 - [CC.LA](https://cc.la) - Free online toolkit for WHOIS, RDAP, DNS, IP WHOIS, SSL certificates, name server history, and network diagnostics (ping/traceroute/MTR).
+- [StackScan](https://www.stackscan.com/) - Search sites by technology, keyword, or the files and assets they serve
 
 ### URLs
 


### PR DESCRIPTION
Adds StackScan to **Domains**, appended to the end of the section.

**Disclosure: I work on StackScan.**

Three ways to search, all of them reverse lookups rather than per-site checks:

- **By technology.** Pick one of 55,000+ named technologies and get the sites and companies running it, with country and industry breakdowns.
- **By keyword.** Find sites by on-page content instead of by stack.
- **By served asset.** Give it a file name, an asset path, or the host an asset loads from, and get every site carrying that footprint. Nothing has to be named or classified first, so a niche plugin, a specific theme build, or a library version with a CVE against it is findable even though no detector exists for it.

The third one is why I think it earns a place here rather than sitting next to per-domain lookup tools.

Free tier on email verification: 100 lifetime API credits, one list, and custom footprint scans. Technology statistics pages are browsable with no account.
