### PR TITLE
Add Offendersearch to People

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ These can be useful for osint and social engineering.
 - [TheOrg](https://theorg.com/) - World's biggest network of public org charts
 - [Xquik](https://xquik.com/) - Search public X posts, inspect public profiles, monitor keywords and use REST or MCP workflows for X data
 - [Sherlock Search](https://www.sherlocksearch.com/) - Upload one photo and Sherlock finds where that face appears across 9+ social platforms and public records
+- [Offendersearch](https://offendersearch.app/) - Search 58 US sex offender registries, covering the 50 states, DC and the US territories, in one query
 
 ### Vehicle
 


### PR DESCRIPTION
Adds one entry.

Offendersearch searches 58 US sex offender registries — the 50 states, DC and the US territories — from a single query, and links out to the official record for each match.

The list already covers this category (Family Watchdog, Black Book Online, Background Checks.org / TruthFinder, BeenVerified, Intelius), so this is a single on-topic addition rather than a new section.

It has a free trial and is paid beyond it — flagging that explicitly since it isn't a free tool. Happy to reword, move it, or drop it if it isn't a fit.