### PR TITLE
Add LiveTrafficCam to Surveillance cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ These can be useful for osint and social engineering.
 - [WorldCam](https://worldcam.eu/) - Webcams from around the world
 - [Webcam Hopper](https://www.webcamhopper.com/) - Live Webcams from around the world
 - [Live Traffic](https://livetraffic.eu/) - Real-time monitoring of Europe’s live traffic cameras
+- [LiveTrafficCam](https://livetrafficcam.com/) - Directory of US state DOT traffic cameras, each checked for a live image
 - [Geocam.ru](https://www.geocam.ru/en/) - Webcams of the world
 - [Moldova's borders webcams](https://www.border.gov.md/camere-web) - Official list of webcams at various border crossings around Moldova
 - [Earth Cam](https://www.earthcam.com/) - Leading network of live streaming webcams for tourism and entertainment


### PR DESCRIPTION
Adds LiveTrafficCam to the Surveillance cameras section, next to the existing livetraffic.eu entry as its US counterpart: a directory of official US state DOT traffic cameras where every camera is health-checked on a rolling schedule, so listings reflect whether a feed actually serves a current image.

Disclosure: I run this site. Line follows the existing format; happy to adjust wording.