### PR TITLE
Move 5 dead links to Not working / Paused, add ctlogs.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [ciphersuite.info](https://ciphersuite.info/) - TLS Ciphersuite Search. Search for a particular cipher suite by using IANA, OpenSSL or GnuTLS name format
 - [certificatedetails](https://certificatedetails.com/) - Online certificate viewer. Inspect and download certificates from your browser
 - [ODIN Certificates Search](https://getodin.com/search/certificates) - ODIN Certificates Search
-- [ctlogs.dev](https://ctlogs.dev)- Certificate Transparency Search & Free CT Logs API
+- [ctlogs.dev](https://ctlogs.dev) - Find TLS/SSL certificates by domain, organization, serial, or fingerprint
 
 ### WiFi Networks
 
@@ -699,10 +699,9 @@ make, model, year of manufacture, engine size and all available information
 - [CVE Trends](https://cvetrends.com/) - Monitor trending CVEs in real-time; crowdsourced intel sourced from Twitter, NIST NVD, Reddit, and GitHub
 - [CTSearch](https://ui.ctsearch.entrust.com/ui/ctsearchui) - Certificate Transparency Search Tool
 - [FacebookCT](https://developers.facebook.com/tools/ct/search/) - Search for certificates issued for a given domain and subscribe to notifications from Facebook regarding new certificates
-- [certs.io](https://certs.io/) - Search TLS certificates across the internet.
+- [certs.io](https://certs.io/) - Search TLS certificates across the internet
 - [Riddler](https://riddler.io/) - Allows you to search in a high quality dataset
 - [AskDNS](https://askdns.com/) - Lookup Connected Domain Names and IP Addresses
-
 
 <!-- markdown-link-check-enable -->
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [PhoneBook](https://phonebook.cz/) - Lists all domains, email addresses, or URLs for the given input domain
 - [IntelligenceX](https://intelx.io/) - Search engine and data archive
 - [Omnisint](https://omnisint.io/subdomain-enumeration) - Subdomain enumeration
-- [Riddler](https://riddler.io/) - Allows you to search in a high quality dataset
 - [RobTex](https://www.robtex.com/) - Various kinds of research of IP numbers, Domain names, etc
 - [CentralOps - DomainDossier](https://centralops.net/co/DomainDossier.aspx) - Investigate domains and IP addresses
 - [DomainIQ](https://www.domainiq.com/) - Comprehensive Domain Intelligence
@@ -324,7 +323,6 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [dnsrepo.noc.org](https://dnsrepo.noc.org/) - DNS Database Repository Search
 - [DNSSpy](https://dnsspy.io/) - Monitor, validate and verify your DNS configurations
 - [ZETAlytics](https://zetalytics.com/) - We offer unrivalled geographic diversity and exclusive global network visibility in searchable datasets for use by cyber security analysts
-- [AskDNS](https://askdns.com/) - Lookup Connected Domain Names and IP Addresses
 - [360 PassiveDNS.CN](https://passivedns.cn/) - Biggest public available db in China designed for security and research purpose
 - [MXtoolbox](https://mxtoolbox.com/SuperTool.aspx) - All of your MX record, DNS, blacklist and SMTP diagnostics in one integrated tool
 - [NSLookup.io](https://www.nslookup.io/) - Find all DNS records for a domain name using this online tool
@@ -338,16 +336,14 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 ### Certificates
 
 - [Crt.sh](https://crt.sh/) - Certificate Search
-- [CTSearch](https://ui.ctsearch.entrust.com/ui/ctsearchui) - Certificate Transparency Search Tool
 - [tls.bufferover.run](https://tls.bufferover.run/) - Quickly find certificates in IPv4 space
 - [CertSpotter](https://sslmate.com/certspotter/) - Monitors your domains for expiring, unauthorized, and invalid SSL certificates
 - [SynapsInt](https://synapsint.com/) - The unified OSINT research tool
 - [Censys Search - Certificates](https://search.censys.io/#) - Certificates Search
 - [ciphersuite.info](https://ciphersuite.info/) - TLS Ciphersuite Search. Search for a particular cipher suite by using IANA, OpenSSL or GnuTLS name format
 - [certificatedetails](https://certificatedetails.com/) - Online certificate viewer. Inspect and download certificates from your browser
-- [FacebookCT](https://developers.facebook.com/tools/ct/search/) - Search for certificates issued for a given domain and subscribe to notifications from Facebook regarding new certificates
-- [certs.io](https://certs.io/) - Search TLS certificates across the internet.
 - [ODIN Certificates Search](https://getodin.com/search/certificates) - ODIN Certificates Search
+- [ctlogs.dev](https://ctlogs.dev)- Certificate Transparency Search & Free CT Logs API
 
 ### WiFi Networks
 
@@ -701,6 +697,12 @@ make, model, year of manufacture, engine size and all available information
 - [NetoGraph](https://netograph.io/) - Captures and indexes detailed, low-level snapshots of website behaviour
 - [Hashdd](https://hashdd.com/) - Known Good Cryptographic Hashes
 - [CVE Trends](https://cvetrends.com/) - Monitor trending CVEs in real-time; crowdsourced intel sourced from Twitter, NIST NVD, Reddit, and GitHub
+- [CTSearch](https://ui.ctsearch.entrust.com/ui/ctsearchui) - Certificate Transparency Search Tool
+- [FacebookCT](https://developers.facebook.com/tools/ct/search/) - Search for certificates issued for a given domain and subscribe to notifications from Facebook regarding new certificates
+- [certs.io](https://certs.io/) - Search TLS certificates across the internet.
+- [Riddler](https://riddler.io/) - Allows you to search in a high quality dataset
+- [AskDNS](https://askdns.com/) - Lookup Connected Domain Names and IP Addresses
+
 
 <!-- markdown-link-check-enable -->
 


### PR DESCRIPTION
Four hosts no longer resolve:
CTSearch, ui.ctsearch.entrust.com, no A record
certs.io, SERVFAIL
AskDNS, askdns.com, NXDOMAIN
Riddler, riddler.io, no A record

FacebookCT returns a hard 404, Meta retired the tool, the page is gone.

All five moved to Not working / Paused, inside the link-check-disabled block, rather than deleted.

Also added ctlogs.dev to Certificates. Disclosure: I built it, happy to split this into two PRs.